### PR TITLE
Add guidelines and environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# Agent Instructions for cv2kinesis
+
+## Repository Overview
+This repository contains two main subprojects:
+
+- **image-processing** – a local event-driven prototype using RabbitMQ and MinIO.
+- **video-processing** – an AWS CDK based solution for streaming video frames to a YOLOv8 detector running on ECS. It includes infrastructure code and sample producers/consumers.
+
+Both projects are written primarily in Python.
+
+## Coding Guidelines
+- **Style**: Format Python code with [black](https://black.readthedocs.io/en/stable/) using the default line length. Use 4 spaces for indentation.
+- **Imports**: Group built-in, third‑party and local imports separately.
+- **Docstrings**: Public functions and modules should include docstrings explaining their purpose.
+- **Shell scripts**: start with `#!/usr/bin/env bash` and include `set -euo pipefail`.
+- **Commit messages**: write a short imperative sentence in present tense.
+
+## Testing
+- Before committing, run `python -m pytest` from the repository root. The tests rely on optional heavy dependencies (Docker, OpenCV, ultralytics). If they fail due to missing packages or services, include the provided disclaimer in the PR.
+
+## Environment Setup
+A helper script `setup.sh` in the repository root installs the required tools. Run it once after cloning to create a virtual environment, install Python requirements for all components and install the AWS CDK CLI.
+
+```bash
+./setup.sh
+```
+
+This prepares the environment for CDK commands such as `cdk synth` or `cdk deploy`.
+
+## Project Goal
+The main focus of this repository is building a complete Python CDK stack for a unified, hybrid infrastructure handling both images and videos in AWS region `eu-central-1`. Separate configurations for **test/dev** and **prod** should be maintained, and useful outputs should be provided for frontend integration.

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create Python virtual environment
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+
+# Install dependencies for all components
+pip install -r video-processing/requirements.txt
+pip install -r video-processing/producer_and_consumer_examples/requirements.txt
+pip install -r video-processing/cdk/requirements.txt
+pip install -r image-processing/frontend/requirements.txt
+pip install -r image-processing/grayscale_service/requirements.txt
+
+# Install AWS CDK CLI
+npm install -g aws-cdk
+
+echo "Environment ready. Activate with: source .venv/bin/activate"


### PR DESCRIPTION
## Summary
- document coding and testing guidelines in `AGENTS.md`
- add `setup.sh` to prepare Python environment and install the AWS CDK CLI

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_686fd6c92970832db21ca2bc5c234772